### PR TITLE
Add Role Check Decorator 

### DIFF
--- a/app/apis/__init__.py
+++ b/app/apis/__init__.py
@@ -1,1 +1,30 @@
+from functools import wraps
+from http import HTTPStatus
+
+from flask_jwt_extended import get_jwt
+
 MSG = "message"
+TRAINER = "trainer"
+MEMBER = "member"
+
+FORBIDDEN_ROLE_MESSAGE = "Current role is not allowed to access this resource"
+
+
+def require_roles(*allowed_roles: str):
+	if len(allowed_roles) == 0:
+		raise ValueError("At least one role must be provided")
+
+	allowed_set = set(allowed_roles)
+
+	def decorator(fn):
+		@wraps(fn)
+		def wrapper(*args, **kwargs):
+			claims = get_jwt()
+			user_role = claims.get("role")
+			if user_role not in allowed_set:
+				return {MSG: FORBIDDEN_ROLE_MESSAGE}, HTTPStatus.FORBIDDEN
+			return fn(*args, **kwargs)
+
+		return wrapper
+
+	return decorator

--- a/app/apis/classes.py
+++ b/app/apis/classes.py
@@ -3,7 +3,7 @@ from flask import request
 from flask_jwt_extended import get_jwt, get_jwt_identity, jwt_required
 from http import HTTPStatus
 from datetime import datetime, timezone
-from app.apis import MSG
+from app.apis import MSG, TRAINER, require_roles
 from app.db.users import UserResource
 from app.db.classes import ClassResource
 from app.services.email_service import EmailService
@@ -122,6 +122,7 @@ class ClassList(Resource):
 
 class CreateClass(Resource):
     @jwt_required()
+    @require_roles(TRAINER)
     @api.doc(security='Bearer', params={
         "class_name": "Name/title of the class",
         "start_date": "Start datetime for the class (must be in the future)",
@@ -137,11 +138,6 @@ class CreateClass(Resource):
     
     def post(self):
         current_user = get_jwt_identity()
-        claims = get_jwt()
-        user_role = claims.get("role")
-
-        if user_role != "trainer":
-            return {MSG: "Only trainers allowed"}, HTTPStatus.FORBIDDEN
 
         assert isinstance(request.json, dict)
 

--- a/app/apis/classes.py
+++ b/app/apis/classes.py
@@ -314,10 +314,6 @@ class ClassReminder(Resource):
     @api.response(HTTPStatus.FORBIDDEN, "Role not allowed", remind_class_forbidden)
     @api.response(HTTPStatus.BAD_REQUEST, "Class is in the past or has invalid date", remind_class_bad_request)
     def post(self, class_id):
-        claims = get_jwt()
-        user_role = claims.get("role")
-        if user_role != "trainer":
-            return {MSG: "Only trainers allowed"}, HTTPStatus.FORBIDDEN
 
         current_user = get_jwt_identity()
         user_resource = UserResource()

--- a/app/apis/classes.py
+++ b/app/apis/classes.py
@@ -3,7 +3,7 @@ from flask import request
 from flask_jwt_extended import get_jwt, get_jwt_identity, jwt_required
 from http import HTTPStatus
 from datetime import datetime, timezone
-from app.apis import MSG, TRAINER, require_roles
+from app.apis import MSG, MEMBER, TRAINER, FORBIDDEN_ROLE_MESSAGE, require_roles
 from app.db.users import UserResource
 from app.db.classes import ClassResource
 from app.services.email_service import EmailService
@@ -31,7 +31,7 @@ create_class_error = api.model("CreateClassError", {
 })
 
 create_class_forbidden = api.model("CreateClassForbidden", {
-    MSG: fields.String(example="Only trainers are allowed to create classes")
+    MSG: fields.String(example=FORBIDDEN_ROLE_MESSAGE)
 })
 
 create_class_bad_request = api.model("CreateClassBadRequest", {
@@ -59,7 +59,7 @@ book_class_class_full = api.model("BookClassFull", {
 })
 
 book_class_forbidden = api.model("BookClassForbidden", {
-    MSG: fields.String(example="Only trainers and members allowed")
+    MSG: fields.String(example=FORBIDDEN_ROLE_MESSAGE)
 })
 
 book_class_bad_request = api.model("BookClassBadRequest", {
@@ -132,7 +132,7 @@ class CreateClass(Resource):
     }, description="Create a new class (trainers only)")
     @api.response(HTTPStatus.CREATED, "Class created", create_class_success)
     @api.response(HTTPStatus.NOT_ACCEPTABLE, "Invalid input", create_class_error)
-    @api.response(HTTPStatus.FORBIDDEN, "Only trainers allowed", create_class_forbidden)
+    @api.response(HTTPStatus.FORBIDDEN, FORBIDDEN_ROLE_MESSAGE, create_class_forbidden)
     @api.response(HTTPStatus.BAD_REQUEST, "Failed to create class", create_class_bad_request)
     @api.expect(create_class_model, validate=True)
     
@@ -205,7 +205,7 @@ class ClassBooking(Resource):
     @api.response(HTTPStatus.NOT_FOUND, "Class not found", book_class_not_found)
     @api.response(HTTPStatus.CONFLICT, "Already booked", book_class_conflict)
     @api.response(HTTPStatus.FORBIDDEN, "Class full", book_class_class_full)
-    @api.response(HTTPStatus.FORBIDDEN, "Role not allowed", book_class_forbidden)
+    @api.response(HTTPStatus.FORBIDDEN, FORBIDDEN_ROLE_MESSAGE, book_class_forbidden)
     @api.response(HTTPStatus.BAD_REQUEST, "Booking failed", book_class_bad_request)
     def post(self, class_id):
         current_user = get_jwt_identity()
@@ -302,6 +302,7 @@ class ClassMembers(Resource):
 @api.route("/remind/<string:class_id>")
 class ClassReminder(Resource):
     @jwt_required()
+    @require_roles(TRAINER)
     @api.doc(
         security="Bearer",
         params={"class_id": "Class ID (Mongo ObjectId string)"},

--- a/tests/test_remind_class.py
+++ b/tests/test_remind_class.py
@@ -27,7 +27,7 @@ def test_remind_class_unauthorized_user(client, member_headers):
     # members should not be able to send reminders
     response = client.post("/classes/remind/some_class_id", headers = member_headers)
     assert response.status_code == HTTPStatus.FORBIDDEN
-    assert response.json["message"] == "Only trainers allowed"
+    assert response.json["message"] == "Current role is not allowed to access this resource"
     
 @patch(MOCK_GET_USER) # becomes input no2 for following func
 @patch(MOCK_GET_CLASS_MEMBERS) # becomes input no1 for following func


### PR DESCRIPTION
Removed string literals for roles and replaced with constants in `apis/__init__.py`. 
Added a decorator function that can be applied to endpoints to remove the duplicate code for getting validating user roles / authorization.

To use, simply add `@require_roles(MEMBER, TRAINER)` after the `@jwt_required()` decorator.

Also added `FORBIDDEN_ROLE_MESSAGE` to standardize response message for forbidden role api responses. 

Works on #91 and #86 and #85